### PR TITLE
Configure TravisCI to send notifications to BitBot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,7 @@ deploy:
   local_dir: dist
   on:
     branch: master
+notifications:
+  webhooks:
+    urls:
+      - https://fs-bitbot.herokuapp.com/travis


### PR DESCRIPTION
This entry in the .travis.yml file forwards a verbose payload of information
to our lita travis handler for all travis ci notifications.  Since Travis
does not provide a way to filter notifications by branch in the .travis.yml
file, we will do the filtering and formatting in the lita handler.

DO NOT MERGE until https://github.com/thefrontside/Bitbot/pull/5 is merged.