### PR TITLE
Enable mirage in production.

### DIFF
--- a/mirage/index.js
+++ b/mirage/index.js
@@ -2,8 +2,16 @@
 
 let start = () => {};
 
-if (process.env.NODE_ENV !== 'production') {
-  start = require('./start').default;
-}
+// Currently we run mirage in production because the server side is
+// incomplete.
+//
+// However, when we switch over to the actual API, then we'll want to
+// protect this require with an if statement so that webpack won't attempt to
+// bundle mirage at all.
+//
+// if (process.env.NODE_ENV !== 'production') {
+//   start = require('./start').default;
+// }
+start = require('./start').default;
 
 export default start;

--- a/mirage/start.js
+++ b/mirage/start.js
@@ -8,8 +8,9 @@ import '../tests/force-fetch-polyfill';
 const environment = process.env.NODE_ENV;
 const moduleTypes = ['factories', 'fixtures', 'models', 'serializers', 'identity-managers'];
 
-// only use data from our scenarios in development
-if (environment === 'development') {
+// don't load scenarios in the 'test' environment since you want to
+// create the server configuration by hand to correspond to each test case.
+if (environment !== 'test') {
   moduleTypes.push('scenarios');
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -19,8 +19,6 @@ if (module.hot) {
   module.hot.accept('./components/app', render);
 }
 
-if (process.env.NODE_ENV === 'development') {
-  window.mirage = startMirage();
-}
+window.mirage = startMirage();
 
 render();


### PR DESCRIPTION
In order to demo and also to build out funcitonality with the server being incomplete and not fully defined, it's best to have mirage going everywhere.